### PR TITLE
Fix error message attribute mismatch

### DIFF
--- a/src/main/java/jp/co/aforce/servlet/UserEditExecuteServlet.java
+++ b/src/main/java/jp/co/aforce/servlet/UserEditExecuteServlet.java
@@ -72,7 +72,8 @@ public class UserEditExecuteServlet extends HttpServlet {
                 
             } else {
                 System.out.println("更新失敗 - エラーページへリダイレクト");
-                request.setAttribute("errMessage", "データベース更新に失敗しました");
+                // エラーメッセージの属性名は JSP 側の期待に合わせる
+                request.setAttribute("errorMessage", "データベース更新に失敗しました");
                 RequestDispatcher rd = request.getRequestDispatcher("/views/login-error.jsp");
                 rd.forward(request, response);
             }
@@ -82,7 +83,8 @@ public class UserEditExecuteServlet extends HttpServlet {
             e.printStackTrace();
             
             // 例外発生時エラーページへフォワード
-            request.setAttribute("errMessage", "システムエラー発生: " + e.getMessage());
+            // 例外内容をユーザーに知らせる際も属性名を統一
+            request.setAttribute("errorMessage", "システムエラー発生: " + e.getMessage());
             RequestDispatcher rd = request.getRequestDispatcher("/views/login-error.jsp");
             rd.forward(request, response);
         }


### PR DESCRIPTION
## Summary
- fix `UserEditExecuteServlet` to use `errorMessage` attribute name expected by `login-error.jsp`

## Testing
- `gradle test` *(fails: Directory does not contain a Gradle build)*

------
https://chatgpt.com/codex/tasks/task_e_6842996cf0d88324a95c2d1a6497f9fb